### PR TITLE
Unbreak ambient display while Heads up is disabled

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/NotificationEntryManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NotificationEntryManager.java
@@ -969,7 +969,7 @@ public class NotificationEntryManager implements Dumpable, NotificationInflater.
     }
 
     public boolean shouldPeek(NotificationData.Entry entry, StatusBarNotification sbn) {
-        if (!mUseHeadsUp || mPresenter.isDeviceInVrMode()) {
+        if (!mUseHeadsUp && !mPresenter.isDozing() || mPresenter.isDeviceInVrMode()) {
             if (DEBUG) Log.d(TAG, "No peeking: no huns or vr mode");
             return false;
         }


### PR DESCRIPTION
Google tied in heads up with ambient display and so if you disabled heads up,
you would only see a blank screen with LED pulsing. This commit fixes that!

Change-Id: I33fe60c5f6ef9c5e0ab70f81291f3c71f1845666
Signed-off-by: shagbag913 <sh4gbag913@gmail.com>