### PR TITLE
base: Add three-fingers-swipe to screenshot [1/2]

### DIFF
--- a/core/java/android/app/IActivityManager.aidl
+++ b/core/java/android/app/IActivityManager.aidl
@@ -760,4 +760,9 @@ interface IActivityManager {
      * </p>
      */
     int getBackgroundRestrictionExemptionReason(int uid);
+
+    /**
+     *  Should disable touch if three fingers to screen shot is active?
+     */
+    boolean isSwipeToScreenshotGestureActive();
 }

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5757,7 +5757,13 @@ public final class Settings {
         public static final String[] LEGACY_RESTORE_SETTINGS = {
         };
 
-       /**
+        /**
+         * Three Finger Gesture from Oppo
+         * @hide
+         */
+        public static final String THREE_FINGER_GESTURE = "three_finger_gesture";
+
+        /**
          * These are all public system settings
          *
          * @hide

--- a/core/java/android/view/ViewRootImpl.java
+++ b/core/java/android/view/ViewRootImpl.java
@@ -6649,6 +6649,11 @@ public final class ViewRootImpl implements ViewParent,
             final MotionEvent event = (MotionEvent)q.mEvent;
             mHandwritingInitiator.onTouchEvent(event);
 
+            if (event.getPointerCount() == 3 && isSwipeToScreenshotGestureActive()) {
+                event.setAction(MotionEvent.ACTION_CANCEL);
+                Log.d("teste", "canceling motionEvent because of threeGesture detecting");
+            }
+
             mAttachInfo.mUnbufferedDispatchRequested = false;
             mAttachInfo.mHandlingPointerEvent = true;
             boolean handled = mView.dispatchPointerEvent(event);
@@ -11113,5 +11118,14 @@ public final class ViewRootImpl implements ViewParent,
             return;
         }
         mSurfaceSyncer.merge(mSyncId, syncId, otherSyncer);
+    }
+
+    private boolean isSwipeToScreenshotGestureActive() {
+        try {
+            return ActivityManager.getService().isSwipeToScreenshotGestureActive();
+        } catch (RemoteException e) {
+            Log.e("teste", "isSwipeToScreenshotGestureActive exception", e);
+            return false;
+        }
     }
 }

--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -1557,6 +1557,10 @@ public class ActivityManagerService extends IActivityManager.Stub
 
     static final HostingRecord sNullHostingRecord =
             new HostingRecord(HostingRecord.HOSTING_TYPE_EMPTY);
+
+    final SwipeToScreenshotObserver mSwipeToScreenshotObserver;
+    private boolean mIsSwipeToScreenshotEnabled;
+
     /**
      * Used to notify activity lifecycle events.
      */
@@ -2344,6 +2348,7 @@ public class ActivityManagerService extends IActivityManager.Stub
         mFgBroadcastQueue = mBgBroadcastQueue = mBgOffloadBroadcastQueue =
                 mFgOffloadBroadcastQueue = null;
         mComponentAliasResolver = new ComponentAliasResolver(this);
+        mSwipeToScreenshotObserver = null;
     }
 
     // Note: This method is invoked on the main thread but may need to attach various
@@ -2477,6 +2482,7 @@ public class ActivityManagerService extends IActivityManager.Stub
         mPendingStartActivityUids = new PendingStartActivityUids();
         mTraceErrorLogger = new TraceErrorLogger();
         mComponentAliasResolver = new ComponentAliasResolver(this);
+        mSwipeToScreenshotObserver = new SwipeToScreenshotObserver(mHandler, mContext);
     }
 
     public void setSystemServiceManager(SystemServiceManager mgr) {
@@ -8023,6 +8029,7 @@ public class ActivityManagerService extends IActivityManager.Stub
                     com.android.internal.R.bool.config_multiuserDelayUserDataLocking);
             mUserController.setInitialConfig(userSwitchUiEnabled, maxRunningUsers,
                     delayUserDataLocking);
+            mSwipeToScreenshotObserver.registerObserver();
         }
         mAppErrors.loadAppsNotReportingCrashesFromConfig(res.getString(
                 com.android.internal.R.string.config_appsNotReportingCrashes));
@@ -18516,6 +18523,39 @@ public class ActivityManagerService extends IActivityManager.Stub
     static void traceBegin(long traceTag, String methodName, String subInfo) {
         if (Trace.isTagEnabled(traceTag)) {
             Trace.traceBegin(traceTag, methodName + subInfo);
+        }
+    }
+
+    private class SwipeToScreenshotObserver extends ContentObserver {
+
+        private final Context mContext;
+
+        public SwipeToScreenshotObserver(Handler handler, Context context) {
+            super(handler);
+            mContext = context;
+        }
+
+        public void registerObserver() {
+            mContext.getContentResolver().registerContentObserver(
+                    Settings.System.getUriFor(Settings.System.THREE_FINGER_GESTURE),
+                    false, this, UserHandle.USER_ALL);
+            update();
+        }
+
+        private void update() {
+            mIsSwipeToScreenshotEnabled = Settings.System.getIntForUser(mContext.getContentResolver(),
+                    Settings.System.THREE_FINGER_GESTURE, 0, UserHandle.USER_CURRENT) == 1;
+        }
+
+        public void onChange(boolean selfChange) {
+            update();
+        }
+    }
+
+    @Override
+    public boolean isSwipeToScreenshotGestureActive() {
+        synchronized (this) {
+            return mIsSwipeToScreenshotEnabled && SystemProperties.getBoolean("sys.android.screenshot", false);
         }
     }
 }

--- a/services/core/java/com/android/server/policy/SwipeToScreenshotListener.java
+++ b/services/core/java/com/android/server/policy/SwipeToScreenshotListener.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2019 The PixelExperience Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.server.policy;
+
+import android.content.Context;
+import android.os.SystemProperties;
+import android.provider.Settings;
+import android.util.Log;
+import android.util.DisplayMetrics;
+import android.view.MotionEvent;
+import android.view.WindowManagerPolicyConstants.PointerEventListener;
+
+public class SwipeToScreenshotListener implements PointerEventListener {
+    private static final String TAG = "SwipeToScreenshotListener";
+    private static final int THREE_GESTURE_STATE_NONE = 0;
+    private static final int THREE_GESTURE_STATE_DETECTING = 1;
+    private static final int THREE_GESTURE_STATE_DETECTED_FALSE = 2;
+    private static final int THREE_GESTURE_STATE_DETECTED_TRUE = 3;
+    private static final int THREE_GESTURE_STATE_NO_DETECT = 4;
+    private boolean mBootCompleted;
+    private Context mContext;
+    private boolean mDeviceProvisioned = false;
+    private float[] mInitMotionY;
+    private int[] mPointerIds;
+    private int mThreeGestureState = THREE_GESTURE_STATE_NONE;
+    private int mThreeGestureThreshold;
+    private int mThreshold;
+    private final Callbacks mCallbacks;
+    DisplayMetrics mDisplayMetrics;
+
+    public SwipeToScreenshotListener(Context context, Callbacks callbacks) {
+        mPointerIds = new int[3];
+        mInitMotionY = new float[3];
+        mContext = context;
+        mCallbacks = callbacks;
+        mDisplayMetrics = mContext.getResources().getDisplayMetrics();
+        mThreshold = (int) (50.0f * mDisplayMetrics.density);
+        mThreeGestureThreshold = mThreshold * 3;
+    }
+
+    @Override
+    public void onPointerEvent(MotionEvent event) {
+        if (!mBootCompleted) {
+            mBootCompleted = SystemProperties.getBoolean("sys.boot_completed", false);
+            return;
+        }
+        if (!mDeviceProvisioned) {
+            mDeviceProvisioned = Settings.Global.getInt(mContext.getContentResolver(),
+                Settings.Global.DEVICE_PROVISIONED, 0) != 0;
+            return;
+        }
+        if (event.getAction() == 0) {
+            changeThreeGestureState(THREE_GESTURE_STATE_NONE);
+        } else if (mThreeGestureState == THREE_GESTURE_STATE_NONE && event.getPointerCount() == 3) {
+            if (checkIsStartThreeGesture(event)) {
+                changeThreeGestureState(THREE_GESTURE_STATE_DETECTING);
+                for (int i = 0; i < 3; i++) {
+                    mPointerIds[i] = event.getPointerId(i);
+                    mInitMotionY[i] = event.getY(i);
+                }
+            } else {
+                changeThreeGestureState(THREE_GESTURE_STATE_NO_DETECT);
+            }
+        }
+        if (mThreeGestureState == THREE_GESTURE_STATE_DETECTING) {
+            if (event.getPointerCount() != 3) {
+                changeThreeGestureState(THREE_GESTURE_STATE_DETECTED_FALSE);
+                return;
+            }
+            if (event.getActionMasked() == MotionEvent.ACTION_MOVE) {
+                float distance = 0.0f;
+                int i = 0;
+                while (i < 3) {
+                    int index = event.findPointerIndex(mPointerIds[i]);
+                    if (index < 0 || index >= 3) {
+                        changeThreeGestureState(THREE_GESTURE_STATE_DETECTED_FALSE);
+                        return;
+                    } else {
+                        distance += event.getY(index) - mInitMotionY[i];
+                        i++;
+                    }
+                }
+                if (distance >= ((float) mThreeGestureThreshold)) {
+                    changeThreeGestureState(THREE_GESTURE_STATE_DETECTED_TRUE);
+                    mCallbacks.onSwipeThreeFinger();
+                }
+            }
+        }
+    }
+
+    private void changeThreeGestureState(int state) {
+        if (mThreeGestureState != state){
+            mThreeGestureState = state;
+            boolean shouldEnableProp = mThreeGestureState == THREE_GESTURE_STATE_DETECTED_TRUE ||
+                mThreeGestureState == THREE_GESTURE_STATE_DETECTING;
+            try {
+                SystemProperties.set("sys.android.screenshot", shouldEnableProp ? "true" : "false");
+            } catch(Exception e) {
+                Log.e(TAG, "Exception when setprop", e);
+            }
+        }
+    }
+
+    private boolean checkIsStartThreeGesture(MotionEvent event) {
+        if (event.getEventTime() - event.getDownTime() > 500) {
+            return false;
+        }
+        int height = mDisplayMetrics.heightPixels;
+        int width = mDisplayMetrics.widthPixels;
+        float minX = Float.MAX_VALUE;
+        float maxX = Float.MIN_VALUE;
+        float minY = Float.MAX_VALUE;
+        float maxY = Float.MIN_VALUE;
+        for (int i = 0; i < event.getPointerCount(); i++) {
+            float x = event.getX(i);
+            float y = event.getY(i);
+            if (y > ((float) (height - mThreshold))) {
+                return false;
+            }
+            maxX = Math.max(maxX, x);
+            minX = Math.min(minX, x);
+            maxY = Math.max(maxY, y);
+            minY = Math.min(minY, y);
+        }
+        if (maxY - minY <= mDisplayMetrics.density * 150.0f) {
+            return maxX - minX <= ((float) (width < height ? width : height));
+        }
+        return false;
+    }
+
+    interface Callbacks {
+        void onSwipeThreeFinger();
+    }
+}


### PR DESCRIPTION
The feature is ported from Oppo ColorOS.
With the options on, users can swipe down
on the screen to have a screenshot.
Original smali port by: wuxianlin

Change-Id: I87ed333f81e1259758ea899bf019061d8ab85fd0

base: Improvements for swipe to screenshot

* Cancel touch events when tap with three fingers

* Dyrex2004: Fix typos (Screnshot -> Screenshot)

Change-Id: I6e1228e4101aa357d1e26ca6d0db1c44428ef367

base: SwipeToScreenshot: Import MIUI implementation

Reverse engineered from Xiaomi/beryllium/beryllium:9/PKQ1.180729.001/9.2.25:user/release-keys

Change-Id: I1d5938457b7cc4c5ef1fec235d27d8a40526961a
Signed-off-by: Omkar Chandorkar <gotenksIN@aospa.co>
Signed-off-by: Dhruv <dhruvgera61@gmail.com>