### PR TITLE
base: Allow disabling color inversion support [1/2]

### DIFF
--- a/core/res/res/values/bootleg_config.xml
+++ b/core/res/res/values/bootleg_config.xml
@@ -121,4 +121,7 @@
         <item>org.lineageos.recorder</item>
         <item>org.lineageos.aperture</item>
     </string-array>
+
+    <!-- Display color inversion availability -->
+    <bool name="config_displayInversionAvailable">true</bool>
 </resources>

--- a/core/res/res/values/bootleg_symbols.xml
+++ b/core/res/res/values/bootleg_symbols.xml
@@ -88,4 +88,7 @@
     <!-- App lock -->
     <java-symbol type="string" name="unlock_application" />
     <java-symbol type="array" name="config_appLockAllowedSystemApps" />
+
+    <!-- Display color inversion availability -->
+    <java-symbol type="bool" name="config_displayInversionAvailable" />
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/ScreenDecorations.java
+++ b/packages/SystemUI/src/com/android/systemui/ScreenDecorations.java
@@ -606,7 +606,10 @@ public class ScreenDecorations extends CoreStartable implements Tunable , Dumpab
             removeHwcOverlay();
         }
 
-        if (hasOverlays() || hasHwcOverlay()) {
+        final boolean available = mContext.getResources().getBoolean(
+                    com.android.internal.R.bool.config_displayInversionAvailable);
+        if (!available) return;
+        if ((hasOverlays() || hasHwcOverlay())) {
             if (mIsRegistered) {
                 return;
             }

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/ColorInversionTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/ColorInversionTile.java
@@ -130,6 +130,12 @@ public class ColorInversionTile extends QSTileImpl<BooleanState> {
     }
 
     @Override
+    public boolean isAvailable() {
+        return mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_displayInversionAvailable);
+    }
+
+    @Override
     public int getMetricsCategory() {
         return MetricsEvent.QS_COLORINVERSION;
     }

--- a/services/core/java/com/android/server/display/color/ColorDisplayService.java
+++ b/services/core/java/com/android/server/display/color/ColorDisplayService.java
@@ -381,8 +381,10 @@ public final class ColorDisplayService extends SystemService {
                 false /* notifyForDescendants */, mContentObserver, mCurrentUser);
         cr.registerContentObserver(System.getUriFor(System.DISPLAY_COLOR_MODE),
                 false /* notifyForDescendants */, mContentObserver, mCurrentUser);
-        cr.registerContentObserver(Secure.getUriFor(Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED),
-                false /* notifyForDescendants */, mContentObserver, mCurrentUser);
+        if (isAccessibilityInversionAvailable()) {
+            cr.registerContentObserver(Secure.getUriFor(Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED),
+                    false /* notifyForDescendants */, mContentObserver, mCurrentUser);
+        }
         cr.registerContentObserver(
                 Secure.getUriFor(Secure.ACCESSIBILITY_DISPLAY_DALTONIZER_ENABLED),
                 false /* notifyForDescendants */, mContentObserver, mCurrentUser);
@@ -570,7 +572,13 @@ public final class ColorDisplayService extends SystemService {
 
     private boolean isAccessiblityInversionEnabled() {
         return Secure.getIntForUser(getContext().getContentResolver(),
-            Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED, 0, mCurrentUser) != 0;
+            Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED, 0, mCurrentUser) != 0
+            && isAccessibilityInversionAvailable();
+    }
+
+    private boolean isAccessibilityInversionAvailable() {
+        return getContext().getResources().getBoolean(
+                com.android.internal.R.bool.config_displayInversionAvailable);
     }
 
     private boolean isAccessibilityEnabled() {

--- a/services/core/java/com/android/server/wm/WindowManagerService.java
+++ b/services/core/java/com/android/server/wm/WindowManagerService.java
@@ -799,8 +799,14 @@ public class WindowManagerService extends IWindowManager.Stub
         public SettingsObserver() {
             super(new Handler());
             ContentResolver resolver = mContext.getContentResolver();
-            resolver.registerContentObserver(mDisplayInversionEnabledUri, false, this,
-                    UserHandle.USER_ALL);
+
+            final boolean displayInversionAvailable = mContext.getResources().getBoolean(
+                    com.android.internal.R.bool.config_displayInversionAvailable);
+            if (displayInversionAvailable) {
+                resolver.registerContentObserver(mDisplayInversionEnabledUri, false, this,
+                        UserHandle.USER_ALL);
+            }
+
             resolver.registerContentObserver(mWindowAnimationScaleUri, false, this,
                     UserHandle.USER_ALL);
             resolver.registerContentObserver(mTransitionAnimationScaleUri, false, this,


### PR DESCRIPTION
Via an overlay
Some kernels won't support that no more
Also make sure it's never enabled, even if the setting is set to true

Change-Id: I031d61bf470913d68b7ac361f30a7e501b2622a6